### PR TITLE
When creating a route respect the default key that was being checked, also add a new key 'notFound' to create a NotFoundRoute

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ var pick = (a, b) => typeof a !== 'undefined' ? a : b;
 var capitalize = s => s[0].toUpperCase() + s.slice(1);
 var proper = name => name.split('-').map(capitalize).join('');
 
+// route types
+var defaultRoute = Symbol('defaultRoute');
+var notFoundRoute = Symbol('defaultRoute');
+
 // route is just an object with keys
 // name: string, path: string, isRoute: bool, children: array
 function route(name, ...children) {
@@ -96,9 +100,10 @@ function makeTree(route, parentsPath) {
   return {
     name: route.name,
     path: route.path,
+    type: route.type,
     handlerPath,
     children
   };
 }
 
-module.exports = { route, routes };
+module.exports = { route, routes, notFoundRoute, defaultRoute};

--- a/react-router/generator.js
+++ b/react-router/generator.js
@@ -1,6 +1,6 @@
 var React = require('react');
-var { route, routes } = require('../index');
-var { Route, DefaultRoute } = require('react-router');
+var { route, routes, notFoundRoute, defaultRoute } = require('../index');
+var { NotFoundRoute, Route, DefaultRoute } = require('react-router');
 
 // this generator ties together react-router with reapp-routes
 
@@ -11,9 +11,17 @@ var { Route, DefaultRoute } = require('react-router');
 function generator(route, requirer) {
   route.handler = requirer(route.handlerPath);
 
-  return route.default ?
-    <DefaultRoute {...route} /> :
-    <Route {...route} />;
+  switch (route.type) {
+    case defaultRoute:
+      return <DefaultRoute {...route} />;
+    case notFoundRoute:
+      return <NotFoundRoute {...route} />;
+    default:
+      if (route.type) {
+        console.warn('Warning: Invalid route type passed, creating standard <Route />');
+      }
+      return <Route {...route} />;
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
Hey @natew,

First off, this is such an awesome project! Thank you so much for putting so much effort into it, it saved me a good week to just grab a setup and just go.

So, using reapp-routes I saw there was a check for route.default. I assume that at one time this was passed via opts? I also added support for notFound.

However, I don't think this is right since you should only be able to set one at time. Should I change this to be 'type' and the caller can pass a const? I am impartial how it is done, as long as the API allows it.
